### PR TITLE
callbacks - Add login and login fail callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ const App = () => (
     fetchUser={() => new Promise(resolve => resolve())}
     getters={authGetters}
     onLogout={() => alert('You\'ve been logged out')}
+    onLogin={() => alert('Welcome to the magical world of the internet')}
+    onLoginFail={() => alert('You shall not pass!')}
   >
     {({ authenticating, authenticated }) => (
       <Loading isLoading={authenticating}>
@@ -113,6 +115,8 @@ export default withAuth(NotAuthenticated)
 - `getDecodedUserId`: Function that decodes the user id from the decoded token. By default is returns the `sub` part of the token.
 - `persistStrategy`: A persistancy strategy object. May be useful to override if you want to persist the token in `AsyncStorage` for a React-Native usecase. Defaults to a localStorage handle, refer to [Persistance strategy](#persistance-strategy) for more info.
 - `onLogout`: Callback that'll be executed when logout is fired
+- `onLogin`: Callback that'll be executed when login is successful (the `fetchUser` did resolve)
+- `onLoginFail`: Callback that'll be executed when login is failure (the `fetchUser` did reject)
 - `children`: Function that expose the render props
 
 ## Render props
@@ -129,7 +133,7 @@ export default withAuth(NotAuthenticated)
 ### Why?
 What makes the provider easy to use, is because he's decoupled with app state. So if you're using GraphQL or json:api compliant api. The provider don't needs to know.
 
-Getters allows you to inject function that get available in your auth provider without composing HOC or things. For instance, I used a json:api compliant app where my local user is stored in redux other entities. Without getters, I was forced to always use Redux`s connect composed with `withAuth` HOC everytime I wanted to use my current user. I added a `getUser` getter to the provider which calls calls my Redux store.
+Getters allows you to inject function that get available in your auth provider without composing HOC or things. For instance, I used a json:api compliant app where my local user is stored in redux other entities. Without getters, I was forced to always use Redux's connect composed with `withAuth` HOC everytime I wanted to use my current user. I added a `getUser` getter to the provider which calls calls my Redux store.
 
 ### How?
 

--- a/dist/AuthenticationProvider.js
+++ b/dist/AuthenticationProvider.js
@@ -122,13 +122,13 @@ function (_React$Component) {
             case 0:
               _context2.prev = 0;
               _context2.next = 3;
-              return _this.props.fetchUser();
+              return _this.props.fetchUser(_this.getProviderState());
 
             case 3:
               payload = _context2.sent;
               decoded = _this.props.decodeToken(_this.state.token);
 
-              _this.handleSuccess(decoded);
+              _this.handleSuccess(decoded, _this.props.onLogin);
 
               return _context2.abrupt("return", payload);
 
@@ -136,7 +136,7 @@ function (_React$Component) {
               _context2.prev = 9;
               _context2.t0 = _context2["catch"](0);
 
-              _this.handleFailure();
+              _this.handleFailure(_this.props.onLoginFail);
 
               return _context2.abrupt("return", _context2.t0);
 
@@ -183,10 +183,11 @@ function (_React$Component) {
   }, {
     key: "handleSuccess",
     value: function handleSuccess(decoded) {
+      var callback = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () {};
       this.setState({
         userId: this.props.getDecodedUserId(decoded),
         authenticating: false
-      });
+      }, callback);
     }
   }, {
     key: "handleFailure",
@@ -236,7 +237,9 @@ AuthenticationProvider.defaultProps = {
     return sub;
   },
   persistStrategy: persistLocalStorage(TOKEN_KEY),
-  onLogout: function onLogout() {}
+  onLogout: function onLogout() {},
+  onLoginFail: function onLoginFail() {},
+  onLogin: function onLogin() {}
 };
 export default AuthenticationProvider;
 export { Consumer };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-auth-guard",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "files": [

--- a/src/demo/App.jsx
+++ b/src/demo/App.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import jwtDecode from 'jwt-decode'
 import Provider from '../lib'
 import Loading from './Loading'
 import NotAuthenticated from './NotAuthenticated'
@@ -11,11 +12,21 @@ const authGetters = {
   }),
 }
 
+const fetchUser = ({ token }) => new Promise((resolve, reject) => {
+  const { sub } = jwtDecode(token)
+  if (sub.toString() === '1') {
+    return resolve()
+  }
+  return reject()
+})
+
 const App = () => (
   <Provider
-    fetchUser={() => new Promise(resolve => resolve())}
+    fetchUser={fetchUser}
     getters={authGetters}
     onLogout={() => alert('Logout')}
+    onLoginFail={() => alert('Could not login')}
+    onLogin={() => alert('Login success!')}
   >
     {({ authenticating, authenticated }) => (
       <Loading isLoading={authenticating}>

--- a/src/demo/Authenticated.jsx
+++ b/src/demo/Authenticated.jsx
@@ -7,7 +7,7 @@ const Authenticated = ({ auth }) => (
   <div>
     <h1>Authenticated</h1>
     <h3>{getFullname(auth.getUser())}</h3>
-    <h5><a href="#" onClick={auth.logout}>Logout</a></h5>
+    <h5><button type="button" onClick={auth.logout}>Logout</button></h5>
   </div>
 )
 

--- a/src/demo/NotAuthenticated.jsx
+++ b/src/demo/NotAuthenticated.jsx
@@ -1,15 +1,18 @@
 import React from 'react'
 import { withAuth } from '../lib'
 
-const FAKE_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.rTCH8cLoGxAm_xw68z-zXVKi9ie6xJn9tnVWjd_9ftE'
+const GOOD_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.rTCH8cLoGxAm_xw68z-zXVKi9ie6xJn9tnVWjd_9ftE'
+const BAD_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyIn0.a7ktMGTybA32ykWHRvhp8FTEsBb-g3FN8aBB6FbgBo0'
 
 const NotAuthenticated = ({ auth }) => {
-  const login = () => auth.updateToken(FAKE_TOKEN)
+  const login = () => auth.updateToken(GOOD_TOKEN)
+  const badLogin = () => auth.updateToken(BAD_TOKEN)
 
   return (
     <div>
       <h1>NotAuthenticated</h1>
       <button type="button" onClick={login}>Login</button>
+      <button type="button" onClick={badLogin}>Bad login</button>
     </div>
   )
 }

--- a/src/lib/AuthenticationProvider.jsx
+++ b/src/lib/AuthenticationProvider.jsx
@@ -23,6 +23,8 @@ class AuthenticationProvider extends React.Component {
     getDecodedUserId: ({ sub }) => sub,
     persistStrategy: persistLocalStorage(TOKEN_KEY),
     onLogout: () => {},
+    onLoginFail: () => {},
+    onLogin: () => {},
   }
 
   constructor(props) {
@@ -83,12 +85,12 @@ class AuthenticationProvider extends React.Component {
 
   fetchUser = async () => {
     try {
-      const payload = await this.props.fetchUser()
+      const payload = await this.props.fetchUser(this.getProviderState())
       const decoded = this.props.decodeToken(this.state.token)
-      this.handleSuccess(decoded)
+      this.handleSuccess(decoded, this.props.onLogin)
       return payload
     } catch (exception) {
-      this.handleFailure()
+      this.handleFailure(this.props.onLoginFail)
       return exception
     }
   }
@@ -97,11 +99,11 @@ class AuthenticationProvider extends React.Component {
     this.handleFailure(this.props.onLogout)
   }
 
-  handleSuccess(decoded) {
+  handleSuccess(decoded, callback = () => {}) {
     this.setState({
       userId: this.props.getDecodedUserId(decoded),
       authenticating: false,
-    })
+    }, callback)
   }
 
   handleFailure(callback = () => {}) {


### PR DESCRIPTION
**What's new**

- You can provide a `onLogin` callback to the provider. The callback will be fired if your `fetchUser` promise resolves.
- You can also provide a `onLoginFail` callback. The callback will be fired if your `fetchUser` promise rejects.
- The `fetchUser` function now receives the current provider state as first argument.